### PR TITLE
work on embedded

### DIFF
--- a/test/tools/cli/CurrentInfo.java
+++ b/test/tools/cli/CurrentInfo.java
@@ -1,0 +1,40 @@
+package tools.cli;
+
+import tools.events.EventType;
+
+public class CurrentInfo {
+    private String fileName;
+    private int eventIndex;
+    private EventType lastEventType;
+
+    public CurrentInfo(String file, int index, EventType lastEventType) {
+        this.fileName = file;
+        this.eventIndex = index;
+        this.lastEventType = lastEventType;
+    }
+
+    public String getFileName() {
+        return this.fileName;
+    }
+
+    public int getEventIndex() {
+        return this.eventIndex;
+    }
+
+    public EventType getLastEventType() {
+        return this.lastEventType;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public void setEventIndex(int eventIndex) {
+        this.eventIndex = eventIndex;
+    }
+
+    public void setLastEventType(EventType lastEventType) {
+        this.lastEventType = lastEventType;
+    }
+
+}

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -64,7 +64,8 @@ public final class IonProcess {
         }
 
         //this object stores data for ErrorReport.
-        ProcessContext processContext = new ProcessContext(null, -1, null, null, null);
+        ProcessContext processContext = new ProcessContext(null, -1,
+                null, null, null);
         try (
                 //Initialize output stream, never return null. (default value: STDOUT)
                 OutputStream outputStream = initOutputStream(parsedArgs, SYSTEM_OUT_DEFAULT_VALUE);

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -47,7 +47,7 @@ public final class IonProcess {
 
     public static void main(String[] args) {
 
-        String[] b = {"-f","events","embedded","-o","123"};
+        String[] b = {"-f","events","embedded"};
         args = b;
         IonProcess.ProcessArgs parsedArgs = new IonProcess.ProcessArgs();
         CmdLineParser parser = new CmdLineParser(parsedArgs);
@@ -297,17 +297,21 @@ public final class IonProcess {
         return new Event(eventType, ionType, fieldName, annotations, valueText, valueBinary, imports, depth);
     }
 
-    private static boolean isSameSymbolTable(SymbolTable x, SymbolTable y) {
-        if (x == null && y == null) return true;
-        else if (x != null && y == null) return false;
-        else if (x == null && y != null) return false;
-        else if (x.isSystemTable() && y.isSystemTable()) {
-            return (x.getVersion() == y.getVersion());
-        } else if (x.isSharedTable() && y.isSharedTable()) {
-            return (x.getName() == y.getName() & (x.getVersion() == y.getVersion()));
-        } else if (x.isLocalTable() && y.isLocalTable()) {
-            SymbolTable[] xTable = x.getImportedTables();
-            SymbolTable[] yTable = y.getImportedTables();
+    private static boolean isSameSymbolTable(SymbolTable newTable, SymbolTable curTable) {
+        if (newTable == null && curTable == null) return true;
+        if (newTable != null && curTable == null) return false;
+        if (newTable == null && curTable != null) return false;
+
+        //if a local table just appended symbols, we treat them as same.
+        if (newTable.isLocalTable() && newTable.getImportedTables().length == 0) {
+            return true;
+        } else if (newTable.isSystemTable() && curTable.isSystemTable()) {
+            return (newTable.getVersion() == curTable.getVersion());
+        } else if (newTable.isSharedTable() && curTable.isSharedTable()) {
+            return ((newTable.getName() == curTable.getName()) & (newTable.getVersion() == curTable.getVersion()));
+        } else if (newTable.isLocalTable() && curTable.isLocalTable()) {
+            SymbolTable[] xTable = newTable.getImportedTables();
+            SymbolTable[] yTable = curTable.getImportedTables();
             //compare imports
             if (xTable.length == yTable.length) {
                 for (int i = 0; i < xTable.length; i++) {

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -44,6 +44,7 @@ public final class IonProcess {
     private static final int USAGE_ERROR_EXIT_CODE = 1;
     private static final int IO_ERROR_EXIT_CODE = 2;
     private static final int BUFFER_SIZE = 128 * 1024;
+    private static final IonSystem ION_SYSTEM = IonSystemBuilder.standard().build();
     private static final String SYSTEM_OUT_DEFAULT_VALUE = "out";
     private static final String SYSTEM_ERR_DEFAULT_VALUE = "err";
     private static final String EMBEDDED_STREAM_ANNOTATION = "embedded_documents";
@@ -325,7 +326,7 @@ public final class IonProcess {
                 ImportDescriptor[] imports = event.getImports();
                 SymbolTable[] symbolTables = new SymbolTable[imports.length];
                 for (int i = 0; i < imports.length; i++) {
-                    SymbolTable symbolTable = IonSystemBuilder.standard().build().newSharedSymbolTable(
+                    SymbolTable symbolTable = ION_SYSTEM.newSharedSymbolTable(
                             imports[i].getImportName(), imports[i].getVersion(), null);
                     symbolTables[i] = symbolTable;
                 }
@@ -393,7 +394,7 @@ public final class IonProcess {
                         ImportDescriptor[] imports = event.getImports();
                         SymbolTable[] symbolTables = new SymbolTable[imports.length];
                         for (int i = 0; i < imports.length; i++) {
-                            SymbolTable symbolTable = IonSystemBuilder.standard().build().newSharedSymbolTable(
+                            SymbolTable symbolTable = ION_SYSTEM.newSharedSymbolTable(
                                     imports[i].getImportName(), imports[i].getVersion(), null);
                             symbolTables[i] = symbolTable;
                         }
@@ -436,7 +437,7 @@ public final class IonProcess {
                     break;
                 case "field_name":
                     ionReader.stepIn();
-                    String fieldText = "";
+                    String fieldText = null;
                     int fieldSid = -1;
                     while (ionReader.next() != null) {
                         switch (ionReader.getFieldName()) {
@@ -506,13 +507,12 @@ public final class IonProcess {
         }
         //compare text value and binary value
         if (textValue != null && binaryValue != null) {
-            IonSystem ionSystem = IonSystemBuilder.standard().build();
-            IonValue text = ionSystem.singleValue(textValue);
-            IonValue binary = ionSystem.singleValue(binaryValue);
+            IonValue text = ION_SYSTEM.singleValue(textValue);
+            IonValue binary = ION_SYSTEM.singleValue(binaryValue);
             if (!Equivalence.ionEquals(text, binary)) {
                 throw new IonException("invalid Event: Text value and Binary value are different");
             } else {
-                IonValue v = IonSystemBuilder.standard().build().singleValue(textValue);
+                IonValue v = text;
                 event.setValue(v);
             }
         }
@@ -604,7 +604,7 @@ public final class IonProcess {
                 tempWriter.finish();
                 String valueText = textOut.toString("utf-8");
                 String[] s = valueText.split("::");
-                value = IonSystemBuilder.standard().build().singleValue(s[s.length -1]);
+                value = ION_SYSTEM.singleValue(s[s.length -1]);
             }
         }
 

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -436,7 +436,7 @@ public final class IonProcess {
                     break;
                 case "field_name":
                     ionReader.stepIn();
-                    String fieldText = null;
+                    String fieldText = "";
                     int fieldSid = -1;
                     while (ionReader.next() != null) {
                         switch (ionReader.getFieldName()) {
@@ -560,20 +560,13 @@ public final class IonProcess {
         BufferedOutputStream outputStream = null;
         switch (defaultValue) {
             case SYSTEM_OUT_DEFAULT_VALUE:
-                if (args.getOutputFormat() == OutputFormat.NONE) {
-                    try (NoOpOutputStream trivialOut = new NoOpOutputStream()) {
-                        outputStream = new BufferedOutputStream(trivialOut, BUFFER_SIZE);
-                    }
+                String outputFile = args.getOutputFile();
+                if (outputFile != null && outputFile.length() != 0) {
+                    File myFile = new File(outputFile);
+                    FileOutputStream out = new FileOutputStream(myFile);
+                    outputStream = new BufferedOutputStream(out, BUFFER_SIZE);
                 } else {
-                    String outputFile = args.getOutputFile();
-                    if (outputFile != null && outputFile.length() != 0) {
-                        File myFile = new File(outputFile);
-                        FileOutputStream out = new FileOutputStream(myFile);
-                        outputStream = new BufferedOutputStream(out, BUFFER_SIZE);
-                    } else {
-                        outputStream = new BufferedOutputStream(System.out, BUFFER_SIZE);
-                    }
-                }
+                    outputStream = new BufferedOutputStream(System.out, BUFFER_SIZE); }
                 break;
             case SYSTEM_ERR_DEFAULT_VALUE:
                 String errorReport = args.getErrorReport();

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -45,10 +45,7 @@ public final class IonProcess {
     private static final String SYSTEM_ERR_DEFAULT_VALUE = "err";
     private static final String EMBEDDED_STREAM_ANNOTATION = "embedded_documents";
 
-    public static void main(String[] args) {
-        String[] b = {"-f","events","test1","bad"};
-        args = b;
-
+    public static void main(final String[] args) {
         ProcessArgs parsedArgs = new ProcessArgs();
         CmdLineParser parser = new CmdLineParser(parsedArgs);
         parser.getProperties().withUsageWidth(CONSOLE_WIDTH);
@@ -81,7 +78,6 @@ public final class IonProcess {
         if (args.getOutputFormat() == OutputFormat.EVENTS) {
             ionWriterForOutput.writeSymbol("$ion_event_stream");
         }
-
         CurrentInfo currentInfo = new CurrentInfo(null, 1);
 
         for (String path : args.getInputFiles()) {
@@ -269,6 +265,7 @@ public final class IonProcess {
                 } else {
                     outputStream = new BufferedOutputStream(System.err, BUFFER_SIZE);
                 }
+                break;
         }
         return outputStream;
     }
@@ -350,8 +347,9 @@ public final class IonProcess {
     }
 
     private static boolean isEmbeddedStream(IonReader ionReader) {
+        IonType ionType = ionReader.getType();
         String[] annotations = ionReader.getTypeAnnotations();
-        return (ionReader.getType() == IonType.SEXP || ionReader.getType() == IonType.LIST)
+        return (ionType == IonType.SEXP || ionType == IonType.LIST)
                 && ionReader.getDepth() == 0
                 && annotations.length > 0
                 && annotations[0].equals(EMBEDDED_STREAM_ANNOTATION);
@@ -394,7 +392,6 @@ public final class IonProcess {
             this.eventIndex = index;
         }
     }
-
 
     static class ProcessArgs {
         private static final String DEFAULT_FORMAT_VALUE = OutputFormat.PRETTY.toString();

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -5,6 +5,8 @@ import com.amazon.ion.IonReader;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.IonType;
 import com.amazon.ion.SymbolToken;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.FakeSymbolToken;
 import com.amazon.ion.IonException;
 import com.amazon.ion.system.IonBinaryWriterBuilder;
 import com.amazon.ion.system.IonReaderBuilder;
@@ -25,16 +27,16 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.InputStream;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
  *  Read the input file(s) (optionally, specifying ReadInstructions or a filter) and re-write in the format
  *  specified by --output
- *
- *  For information about the supported output formats, see {@link OutputFormat}.
  */
 public final class IonProcess {
     private static final int CONSOLE_WIDTH = 120; // Only used for formatting the USAGE message
@@ -44,6 +46,7 @@ public final class IonProcess {
     private static final String SYSTEM_OUT_DEFAULT_VALUE = "out";
     private static final String SYSTEM_ERR_DEFAULT_VALUE = "err";
     private static final String EMBEDDED_STREAM_ANNOTATION = "embedded_documents";
+    private static final String EVENT_STREAM = "$ion_event_stream";
 
     public static void main(final String[] args) {
         ProcessArgs parsedArgs = new ProcessArgs();
@@ -59,9 +62,9 @@ public final class IonProcess {
         }
 
         try (
-                //Initialize output stream (default value: STDOUT)
+                //Initialize output stream, never return null. (default value: STDOUT)
                 OutputStream outputStream = initOutputStream(parsedArgs, SYSTEM_OUT_DEFAULT_VALUE);
-                //Initialize error report (default value: STDERR)
+                //Initialize error report, never return null. (default value: STDERR)
                 OutputStream errorReportOutputStream = initOutputStream(parsedArgs, SYSTEM_ERR_DEFAULT_VALUE);
                 IonWriter ionWriterForOutput = outputFormat.createIonWriter(outputStream);
                 IonWriter ionWriterForErrorReport = outputFormat.createIonWriter(errorReportOutputStream);
@@ -76,21 +79,24 @@ public final class IonProcess {
                                      IonWriter ionWriterForErrorReport,
                                      ProcessArgs args) throws IOException {
         if (args.getOutputFormat() == OutputFormat.EVENTS) {
-            ionWriterForOutput.writeSymbol("$ion_event_stream");
+            ionWriterForOutput.writeSymbol(EVENT_STREAM);
         }
-        CurrentInfo currentInfo = new CurrentInfo(null, 1);
+        //this object stores data for ErrorReport.
+        CurrentInfo currentInfo = new CurrentInfo(null, 1, null);
 
         for (String path : args.getInputFiles()) {
             try (
                     InputStream inputStream = new BufferedInputStream(new FileInputStream(path));
                     IonReader ionReader = IonReaderBuilder.standard().build(inputStream);
                     ) {
+
                 currentInfo.setFileName(path);
 
-                if (args.getOutputFormat() == OutputFormat.EVENTS) {
-                    processEvents(ionWriterForOutput, ionWriterForErrorReport, ionReader, currentInfo, args);
+                if (isEventStream(ionReader)) {
+                    currentInfo.setEventIndex(currentInfo.getEventIndex() - 1);
+                    processFromEventStream(ionWriterForOutput, ionWriterForErrorReport, ionReader, currentInfo, args);
                 } else {
-                    process(ionWriterForOutput, ionWriterForErrorReport, ionReader, args);
+                    processFromIonStream(ionWriterForOutput, ionWriterForErrorReport, ionReader, currentInfo, args);
                 }
 
                 ionWriterForOutput.finish();
@@ -113,15 +119,34 @@ public final class IonProcess {
                             .writeOutput(ionWriterForErrorReport);
                 }
                 System.exit(IO_ERROR_EXIT_CODE);
+            } catch (FileNotFoundException e) {
+                System.err.println("Could not process '" + path + "': " + e.getMessage());
             }
         }
     }
 
-    private static void process(IonWriter ionWriterForOutput,
+    //
+    //  functions for processing from IonStream
+    //
+
+    private static void processFromIonStream(IonWriter ionWriterForOutput,
+                                             IonWriter ionWriterForErrorReport,
+                                             IonReader ionReader,
+                                             CurrentInfo currentInfo,
+                                             ProcessArgs args) throws IOException {
+        if (args.getOutputFormat() == OutputFormat.EVENTS) {
+            processToEventStreamFromIonStream(ionWriterForOutput,
+                    ionWriterForErrorReport, ionReader, currentInfo);
+        } else {
+            processToNormalFromIonStream(ionWriterForOutput, ionWriterForErrorReport, ionReader, args);
+        }
+    }
+
+    private static void processToNormalFromIonStream(IonWriter ionWriterForOutput,
                                 IonWriter ionWriterForErrorReport,
                                 IonReader ionReader,
                                 ProcessArgs args) throws IOException {
-        while (ionReader.next() != null) {
+        do {
             if (isEmbeddedStream(ionReader)) {
                 ionReader.stepIn();
                 ionWriterForOutput.addTypeAnnotation(EMBEDDED_STREAM_ANNOTATION);
@@ -133,7 +158,7 @@ public final class IonProcess {
                             IonReader tempIonReader = IonReaderBuilder.standard().build(stream);
                             ByteArrayOutputStream text = new ByteArrayOutputStream();
                             IonWriter tempIonWriter =  args.getOutputFormat().createIonWriter(text);
-                            ) {
+                    ) {
                         while (tempIonReader.next() != null) {
                             tempIonWriter.writeValue(tempIonReader);
                         }
@@ -149,32 +174,31 @@ public final class IonProcess {
             } else {
                 ionWriterForOutput.writeValue(ionReader);
             }
-        }
+        } while (ionReader.next() != null);
     }
 
-    private static void processEvents(IonWriter ionWriterForOutput,
+    private static void processToEventStreamFromIonStream(IonWriter ionWriterForOutput,
                                       IonWriter ionWriterForErrorReport,
                                       IonReader ionReader,
-                                      CurrentInfo currentInfo,
-                                      ProcessArgs args) throws IOException {
+                                      CurrentInfo currentInfo) throws IOException {
         //curTable is used for checking if the symbol table changes during the processEvent function.
         SymbolTable curTable = ionReader.getSymbolTable();
 
-        processEvent(ionWriterForOutput, ionWriterForErrorReport, ionReader, curTable, currentInfo);
+        processToEventFromIonStream(ionWriterForOutput, ionWriterForErrorReport, ionReader, curTable, currentInfo);
         new Event(EventType.STREAM_END, null, null, null,
                 null, null, null, 0)
                 .writeOutput(ionWriterForOutput, ionWriterForErrorReport, currentInfo);
     }
 
-    private static void processEvent(IonWriter ionWriterForOutput,
+    private static void processToEventFromIonStream(IonWriter ionWriterForOutput,
                                      IonWriter ionWriterForErrorReport,
                                      IonReader ionReader,
                                      SymbolTable curTable,
                                      CurrentInfo currentInfo) throws IOException {
-        while (ionReader.next() != null) {
+        do {
             if (!isSameSymbolTable(ionReader.getSymbolTable(), curTable)) {
                 curTable = ionReader.getSymbolTable();
-                ImportDescriptor imports[] = symbolTableToImports(curTable.getImportedTables());
+                ImportDescriptor[] imports = symbolTableToImports(curTable.getImportedTables());
                 new Event(EventType.SYMBOL_TABLE, null, null, null,
                         null, null, imports, 0)
                         .writeOutput(ionWriterForOutput, ionWriterForErrorReport, currentInfo);
@@ -193,10 +217,10 @@ public final class IonProcess {
                 while (ionReader.next() != null) {
                     String stream = ionReader.stringValue();
                     try (IonReader tempIonReader = IonReaderBuilder.standard().build(stream)) {
-                        do {
-                            processEvent(ionWriterForOutput, ionWriterForErrorReport, tempIonReader,
+                        while (tempIonReader.next() != null) {
+                            processToEventFromIonStream(ionWriterForOutput, ionWriterForErrorReport, tempIonReader,
                                     curTable, currentInfo);
-                        } while (tempIonReader.next() != null);
+                        }
                     }
                     new Event(EventType.STREAM_END, null, null, null,
                             null, null, null, 0)
@@ -218,7 +242,9 @@ public final class IonProcess {
                 ionReader.stepIn();
 
                 //recursive call
-                processEvent(ionWriterForOutput, ionWriterForErrorReport, ionReader, curTable, currentInfo);
+                ionReader.next();
+                processToEventFromIonStream(ionWriterForOutput,
+                        ionWriterForErrorReport, ionReader, curTable, currentInfo);
 
                 //write a Container_End event and step out
                 new Event(EventType.CONTAINER_END, curType, null, null,
@@ -229,7 +255,329 @@ public final class IonProcess {
                 ionStreamToEvent(EventType.SCALAR, ionReader)
                         .writeOutput(ionWriterForOutput, ionWriterForErrorReport, currentInfo);
             }
+        } while (ionReader.next() != null);
+    }
+
+    //
+    //  functions for processing from EventStream
+    //
+
+    private static void processFromEventStream(IonWriter ionWriterForOutput,
+                                               IonWriter ionWriterForErrorReport,
+                                               IonReader ionReader,
+                                               CurrentInfo currentInfo,
+                                               ProcessArgs args) throws IOException {
+        if (args.getOutputFormat() == OutputFormat.EVENTS) {
+            processToEventStreamFromEventStream(ionWriterForOutput, ionWriterForErrorReport,
+                    ionReader, currentInfo, args);
+        } else {
+            processToNormalFromEventStream(ionWriterForOutput, ionWriterForErrorReport,
+                    ionReader, currentInfo, args);
         }
+    }
+
+    private static void processToEventStreamFromEventStream(IonWriter ionWriterForOutput,
+                                                      IonWriter ionWriterForErrorReport,
+                                                      IonReader ionReader,
+                                                      CurrentInfo currentInfo,
+                                                      ProcessArgs args) throws IOException {
+        try {
+            while (ionReader.next() != null) {
+                Event event = ionStreamToEvent(ionReader);
+                event.validate();
+                currentInfo.setLastEventType(event.getEventType());
+
+                event.writeOutput(ionWriterForOutput, ionWriterForErrorReport, currentInfo);
+
+                //update eventIndex
+                currentInfo.setEventIndex(currentInfo.getEventIndex() + 1);
+            }
+        } catch (IonException | NumberFormatException | IllegalStateException e) {
+            new ErrorDescription(ErrorType.WRITE, e.getMessage(), currentInfo.getFileName(),
+                    currentInfo.getEventIndex()).writeOutput(ionWriterForErrorReport);
+            System.exit(IO_ERROR_EXIT_CODE);
+        }
+    }
+
+    private static void processToNormalFromEventStream(IonWriter ionWriterForOutput,
+                                               IonWriter ionWriterForErrorReport,
+                                               IonReader ionReader,
+                                               CurrentInfo currentInfo,
+                                               ProcessArgs args) throws IOException {
+        try {
+            while (ionReader.next() != null) {
+                //update eventIndex
+                currentInfo.setEventIndex(currentInfo.getEventIndex() + 1);
+
+                Event event = ionStreamToEvent(ionReader);
+                event.validate();
+                currentInfo.setLastEventType(event.getEventType());
+                if (event.getEventType() == EventType.CONTAINER_START) {
+                    if (isEmbeddedEvent(event)) {
+                        embeddedEventToIon(ionReader, ionWriterForOutput, currentInfo, args);
+                    } else {
+                        IonType type = event.getIonType();
+                        String fieldName = event.getFieldName() == null ? null : event.getFieldName().getText();
+                        SymbolToken[] annotations = event.getAnnotations();
+
+                        if (fieldName != null && fieldName.length() != 0) {
+                            ionWriterForOutput.setFieldName(fieldName);
+                        }
+                        if (annotations != null && annotations.length != 0) {
+                            ionWriterForOutput.setTypeAnnotationSymbols(annotations);
+                        }
+                        ionWriterForOutput.stepIn(type);
+                    }
+                } else if (event.getEventType().equals(EventType.CONTAINER_END)) {
+                    ionWriterForOutput.stepOut();
+                } else if (event.getEventType().equals(EventType.SCALAR)) {
+                    writeIonByType(event, ionWriterForOutput);
+                } else if (event.getEventType().equals(EventType.SYMBOL_TABLE)) {
+                    //TODO symbol table
+                    // For SYMBOL_TABLE events, flush the writer's existing local symbol table and any buffered data,
+                    // forcing the writer to create a new local symbol table that imports the list of symbol tables
+                    // declared by the imports field of the Event. This ensures that symbol tokens with unknown text
+                    // that occur in subsequent events in the stream can be written correctly
+                } else if (event.getEventType().equals(EventType.STREAM_END)) {
+                    ionWriterForOutput.finish();
+                }
+            }
+            if (currentInfo.getLastEventType() != EventType.STREAM_END) {
+                throw new IonException("EventStream doesn't end with STREAM_END event");
+            }
+        } catch (IonException | NumberFormatException | IllegalStateException e) {
+            new ErrorDescription(ErrorType.WRITE, e.getMessage(), currentInfo.getFileName(),
+                    currentInfo.getEventIndex()).writeOutput(ionWriterForErrorReport);
+            System.exit(IO_ERROR_EXIT_CODE);
+        }
+    }
+
+    private static void embeddedEventToIon(IonReader ionReader,
+                                           IonWriter ionWriterForOutput,
+                                           CurrentInfo currentInfo,
+                                           ProcessArgs args) throws IOException {
+        ionWriterForOutput.addTypeAnnotation(EMBEDDED_STREAM_ANNOTATION);
+        ionWriterForOutput.stepIn(IonType.SEXP);
+        int depth = 0;
+        boolean finish = false;
+        while (ionReader.next() != null) {
+            try (
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    IonWriter tempWriter = args.getOutputFormat().createIonWriter(out);
+            ) {
+                do {
+                    currentInfo.setEventIndex(currentInfo.getEventIndex() + 1);
+                    Event event = ionStreamToEvent(ionReader);
+                    event.validate();
+                    currentInfo.setLastEventType(event.getEventType());
+
+                    if (isEmbeddedEvent(event)) {
+                        embeddedEventToIon(ionReader, tempWriter, currentInfo, args);
+                    } else if (event.getEventType() == EventType.STREAM_END) {
+                        break;
+                    } else if (event.getEventType() == EventType.SCALAR) {
+                        writeIonByType(event, tempWriter);
+                    } else if (event.getEventType() == EventType.CONTAINER_START) {
+                        depth++;
+                        tempWriter.stepIn(event.getIonType());
+                    } else if (event.getEventType() == EventType.CONTAINER_END) {
+                        if (depth == 0) {
+                            if (event.getIonType() == IonType.SEXP) {
+                                finish = true;
+                                break;
+                            } else {
+                                throw new IonException("invalid CONTAINER_END");
+                            }
+                        }
+                        depth--;
+                        tempWriter.stepOut();
+                    } else if (event.getEventType() == EventType.SYMBOL_TABLE) {
+                        //TODO symbol table
+                    }
+                } while (ionReader.next() != null);
+
+                if (out.size() != 0) {
+                    StringBuilder s = new StringBuilder();
+                    tempWriter.finish();
+                    s.append(out);
+                    ionWriterForOutput.writeString(s.toString());
+                }
+            }
+            if (finish) break;
+        }
+        ionWriterForOutput.stepOut();
+    }
+
+    //
+    //  helper functions
+    //
+
+    private static void writeIonByType(Event event, IonWriter ionWriter) throws IOException {
+        IonType ionType = event.getIonType();
+        SymbolToken field = event.getFieldName();
+        if (field != null) {
+            if (field.getText() != null) {
+                ionWriter.setFieldNameSymbol(field);
+            } else {
+                ionWriter.setFieldName("$0");
+            }
+        } else {
+            if (ionWriter.isInStruct()) ionWriter.setFieldName("$0");
+        }
+
+        switch (ionType) {
+            case NULL:
+                ionWriter.writeNull();
+                break;
+            case BOOL:
+                ionWriter.writeBool(Boolean.parseBoolean(event.getValueText()));
+                break;
+            case INT:
+                ionWriter.writeInt(Integer.parseInt(event.getValueText()));
+                break;
+            case FLOAT:
+            case DECIMAL:
+                ionWriter.writeFloat(Double.parseDouble(event.getValueText()));
+                break;
+            case TIMESTAMP:
+                ionWriter.writeTimestamp(Timestamp.valueOf(event.getValueText()));
+                break;
+            case SYMBOL:
+                ionWriter.writeSymbol(event.getValueText());
+                break;
+            case STRING:
+                String string = event.getValueText();
+                String subString = string.substring(1, string.length()-1);
+                ionWriter.writeString(subString);
+                break;
+            case CLOB:
+                ionWriter.writeClob(event.getValueBinary());
+                break;
+            case BLOB:
+                ionWriter.writeBlob(event.getValueBinary());
+                break;
+            default:
+                throw new IonException("invalid ion_type " + ionType.toString());
+        }
+    }
+
+    private static Event ionStreamToEvent(IonReader ionReader) {
+        Event event = new Event();
+        ionReader.stepIn();
+        while (ionReader.next() != null) {
+            switch (ionReader.getFieldName()) {
+                case "event_type":
+                    event.setEventType(EventType.valueOf(ionReader.stringValue().toUpperCase()));
+                    break;
+                case "ion_type":
+                    event.setIonType(IonType.valueOf(ionReader.stringValue().toUpperCase()));
+                    break;
+                case "field_name":
+                    ionReader.stepIn();
+                    String fieldText = null;
+                    int fieldSid = -1;
+                    while (ionReader.next() != null) {
+                        switch (ionReader.getFieldName()) {
+                            case "text":
+                                fieldText = ionReader.stringValue();
+                                break;
+                            case "sid":
+                                fieldSid = ionReader.intValue();
+                                break;
+                        }
+                    }
+                    FakeSymbolToken symbolToken = new FakeSymbolToken(fieldText, fieldSid);
+                    event.setFieldName(symbolToken);
+                    ionReader.stepOut();
+                    break;
+                case "annotations":
+                    LinkedList<SymbolToken> annotations = new LinkedList<>();
+                    ionReader.stepIn();
+                    while (ionReader.next() != null) {
+                        ionReader.stepIn();
+                        String text = "";
+                        int sid = 0;
+                        while (ionReader.next() != null) {
+                            switch (ionReader.getFieldName()) {
+                                case "text":
+                                    text = ionReader.stringValue();
+                                    break;
+                                case "sid":
+                                    sid = ionReader.intValue();
+                                    break;
+                            }
+                        }
+                        FakeSymbolToken annotation = new FakeSymbolToken(text, sid);
+                        annotations.add(annotation);
+                        ionReader.stepOut();
+                    }
+                    int size = annotations.size();
+                    SymbolToken[] annotationsArray = new SymbolToken[size];
+                    for (int i = 0; i < size; i++) {
+                        annotationsArray[i] = annotations.get(i);
+                    }
+                    event.setAnnotations(annotationsArray);
+                    ionReader.stepOut();
+                    break;
+                case "value_text":
+                    event.setValueText(ionReader.stringValue());
+                    break;
+                case "value_binary":
+                    LinkedList<Integer> intArray = new LinkedList<>();
+                    ionReader.stepIn();
+                    while (ionReader.next() != null) {
+                        intArray.add(ionReader.intValue());
+                    }
+                    byte[] binary = new byte[intArray.size()];
+                    for (int i = 0; i < intArray.size(); i++) {
+                        int val = intArray.get(i);
+                        binary[i] = (byte) (val & 0xff);
+                    }
+                    event.setValueBinary(binary);
+                    ionReader.stepOut();
+                    break;
+                case "imports":
+                    ImportDescriptor[] imports = ionStreamToImportDescriptors(ionReader);
+                    event.setImports(imports);
+                    break;
+                case "depth":
+                    event.setDepth(ionReader.intValue());
+                    break;
+            }
+        }
+
+        ionReader.stepOut();
+        return event;
+    }
+
+    private static ImportDescriptor[] ionStreamToImportDescriptors(IonReader ionReader) {
+        LinkedList<ImportDescriptor> imports = new LinkedList<>();
+        ionReader.stepIn();
+        while (ionReader.next() != null) {
+            ionReader.stepIn();
+            ImportDescriptor table = new ImportDescriptor();
+            while (ionReader.next() != null) {
+                switch (ionReader.getFieldName()) {
+                    case "name":
+                        table.setImportName(ionReader.stringValue());
+                        break;
+                    case "max_id":
+                        table.setMaxId(ionReader.intValue());
+                        break;
+                    case "version":
+                        table.setVersion(ionReader.intValue());
+                        break;
+                }
+            }
+            ionReader.stepOut();
+            imports.add(table);
+        }
+        ImportDescriptor[] importsArray = new ImportDescriptor[imports.size()];
+        for (int i = 0; i < imports.size(); i++) {
+            importsArray[i] = imports.get(i);
+        }
+        ionReader.stepOut();
+        return importsArray;
     }
 
     /**
@@ -243,8 +591,9 @@ public final class IonProcess {
         switch (defaultValue) {
             case SYSTEM_OUT_DEFAULT_VALUE:
                 if (args.getOutputFormat() == OutputFormat.NONE) {
-                    ByteArrayOutputStream trivialOut = new ByteArrayOutputStream();
-                    outputStream = new BufferedOutputStream(trivialOut, BUFFER_SIZE);
+                    try (ByteArrayOutputStream trivialOut = new ByteArrayOutputStream()) {
+                        outputStream = new BufferedOutputStream(trivialOut, BUFFER_SIZE);
+                    }
                 } else {
                     String outputFile = args.getOutputFile();
                     if (outputFile != null && outputFile.length() != 0) {
@@ -309,14 +658,14 @@ public final class IonProcess {
     private static boolean isSameSymbolTable(SymbolTable newTable, SymbolTable curTable) {
         if (newTable == null && curTable == null) return true;
         else if (newTable != null && curTable == null) return false;
-        else if (newTable == null && curTable != null) return false;
+        else if (newTable == null) return false;
 
         if (newTable.isLocalTable() && newTable.getImportedTables().length == 0) {
             return true;
         } else if (newTable.isSystemTable() && curTable.isSystemTable()) {
             return newTable.getVersion() == curTable.getVersion();
         } else if (newTable.isSharedTable() && curTable.isSharedTable()) {
-            return (newTable.getName() == curTable.getName()) & (newTable.getVersion() == curTable.getVersion());
+            return (newTable.getName().equals(curTable.getName())) & (newTable.getVersion() == curTable.getVersion());
         } else if (newTable.isLocalTable() && curTable.isLocalTable()) {
             SymbolTable[] xTable = newTable.getImportedTables();
             SymbolTable[] yTable = curTable.getImportedTables();
@@ -338,7 +687,7 @@ public final class IonProcess {
         if (tables == null || tables.length == 0) return null;
         int size = tables.length;
 
-        ImportDescriptor imports[] = new ImportDescriptor[size];
+        ImportDescriptor[] imports = new ImportDescriptor[size];
         for (int i = 0; i < size; i++) {
             ImportDescriptor table = new ImportDescriptor(tables[i]);
             imports[i] = table;
@@ -355,6 +704,23 @@ public final class IonProcess {
                 && annotations[0].equals(EMBEDDED_STREAM_ANNOTATION);
     }
 
+    private static boolean isEventStream(IonReader ionReader) {
+        return ionReader.next() != null
+                && ionReader.getType() == IonType.SYMBOL
+                && ionReader.symbolValue().getText() != null
+                && ionReader.symbolValue().getText().equals(EVENT_STREAM);
+    }
+
+    private static boolean isEmbeddedEvent(Event event) {
+        SymbolToken[] annotations = event.getAnnotations();
+        return event.getEventType() == EventType.CONTAINER_START
+                && event.getIonType() == IonType.SEXP
+                && annotations != null
+                && annotations.length != 0
+                && annotations[0].getText().equals(EMBEDDED_STREAM_ANNOTATION)
+                && event.getDepth() == 0;
+    }
+
     private static void printHelpTextAndExit(String msg, CmdLineParser parser) {
         System.err.println(msg + "\n");
         System.err.println("\"Process\" reads the input file(s) and re-write in the format specified by --output.\n");
@@ -367,31 +733,9 @@ public final class IonProcess {
         System.exit(USAGE_ERROR_EXIT_CODE);
     }
 
-    public static class CurrentInfo {
-        private String fileName;
-        private int eventIndex;
-
-        public CurrentInfo(String file, int index) {
-            this.fileName = file;
-            this.eventIndex = index;
-        }
-
-        public String getFileName() {
-            return this.fileName;
-        }
-
-        public int getEventIndex() {
-            return this.eventIndex;
-        }
-
-        public void setFileName(String file) {
-            this.fileName = file;
-        }
-
-        public void setEventIndex(int index) {
-            this.eventIndex = index;
-        }
-    }
+    //
+    //  classes
+    //
 
     static class ProcessArgs {
         private static final String DEFAULT_FORMAT_VALUE = OutputFormat.PRETTY.toString();

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -63,7 +63,6 @@ public final class IonProcess {
             printHelpTextAndExit(e.getMessage(), parser);
         }
 
-        //this object stores data for ErrorReport.
         ProcessContext processContext = new ProcessContext(null, -1,
                 null, null, null);
         try (

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -68,7 +68,7 @@ public final class IonProcess {
                 OutputStream errorReportOutputStream = initOutputStream(parsedArgs, SYSTEM_ERR_DEFAULT_VALUE);
                 IonWriter ionWriterForOutput = outputFormat.createIonWriter(outputStream);
                 IonWriter ionWriterForErrorReport = outputFormat.createIonWriter(errorReportOutputStream);
-                ) {
+        ) {
             processFiles(ionWriterForOutput, ionWriterForErrorReport, parsedArgs);
         } catch (IOException e) {
             System.err.println("Failed to close OutputStream: " + e.getMessage());
@@ -88,7 +88,7 @@ public final class IonProcess {
             try (
                     InputStream inputStream = new BufferedInputStream(new FileInputStream(path));
                     IonReader ionReader = IonReaderBuilder.standard().build(inputStream);
-                    ) {
+            ) {
 
                 currentInfo.setFileName(path);
 
@@ -638,7 +638,7 @@ public final class IonProcess {
                     IonWriter textWriter = IonTextWriterBuilder.standard().build(textOut);
                     ByteArrayOutputStream binaryOut = new ByteArrayOutputStream();
                     IonWriter binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOut);
-                    ) {
+            ) {
                 //write Text
                 textWriter.writeValue(ionReader);
                 textWriter.finish();

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -99,7 +99,7 @@ public final class IonProcess {
             ionWriterForOutput.writeSymbol(EVENT_STREAM);
         }
         //this object stores data for ErrorReport.
-        ProcessContext processContext = new ProcessContext(null, -1, null, null);
+        ProcessContext processContext = new ProcessContext(null, -1, null, null, null);
 
         for (String path : args.getInputFiles()) {
             try (

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -48,7 +48,10 @@ public final class IonProcess {
     private static String CURRENT_FILE = null;
     private static int EVENT_INDEX = 1;
 
-    public static void main(final String[] args) {
+    public static void main(String[] args) {
+
+        String[] b = {"-f","events","out.10n"};
+        args = b;
 
         IonProcess.ProcessArgs parsedArgs = new IonProcess.ProcessArgs();
         CmdLineParser parser = new CmdLineParser(parsedArgs);
@@ -96,9 +99,11 @@ public final class IonProcess {
                 InputStream inputStream = new BufferedInputStream(new FileInputStream(path));
                 IonReader ionReader = IonReaderBuilder.standard().build(inputStream);
 
+
                 if (args.getOutputFormat() == OutputFormat.EVENTS) {
                     processEvents(ionWriterForOutput, ionWriterForErrorReport, ionReader);
                 } else {
+                    if(isEventStream(ionReader))
                     process(ionWriterForOutput, ionWriterForErrorReport, ionReader);
                 }
 
@@ -293,6 +298,11 @@ public final class IonProcess {
         return new Event(eventType, ionType, fieldName, annotations, valueText, valueBinary, imports, depth);
     }
 
+    /**
+     * this function converts a Event struct to ion field
+     */
+    private static void EventToIonStream(IonReader ionReader){}
+
     private static boolean isSameSymbolTable(SymbolTable x, SymbolTable y) {
         if (x.isSystemTable() && y.isSystemTable()) {
             return (x.getVersion() == y.getVersion());
@@ -355,6 +365,11 @@ public final class IonProcess {
         parser.printUsage(System.err);
         System.exit(USAGE_ERROR_EXIT_CODE);
     }
+
+    private static boolean isEventStream(IonReader ionReader) {
+        return false;
+    }
+
 
     static class ProcessArgs {
         private static final String DEFAULT_FORMAT_VALUE = OutputFormat.PRETTY.toString();

--- a/test/tools/cli/IonProcess.java
+++ b/test/tools/cli/IonProcess.java
@@ -419,7 +419,7 @@ public final class IonProcess {
             if (field.getText() != null) {
                 ionWriter.setFieldNameSymbol(field);
             } else {
-                ionWriter.setFieldName("$0");
+                if (ionWriter.isInStruct()) ionWriter.setFieldName("$0");
             }
         } else {
             if (ionWriter.isInStruct()) ionWriter.setFieldName("$0");

--- a/test/tools/cli/NoOpOutputStream.java
+++ b/test/tools/cli/NoOpOutputStream.java
@@ -1,0 +1,10 @@
+package tools.cli;
+
+import java.io.OutputStream;
+
+public class NoOpOutputStream extends OutputStream {
+    @Override
+    public void write(int b) {
+        return;
+    }
+}

--- a/test/tools/cli/OutputFormat.java
+++ b/test/tools/cli/OutputFormat.java
@@ -37,12 +37,18 @@ public enum OutputFormat {
             return IonBinaryWriterBuilder.standard().build(outputStream);
         }
     },
+    /**
+     * Event Stream
+     */
     EVENTS {
         @Override
         public IonWriter createIonWriter(OutputStream outputStream) {
             return IonTextWriterBuilder.pretty().build(outputStream);
         }
     },
+    /**
+     * None
+     */
     NONE {
         @Override
         public IonWriter createIonWriter(OutputStream outputStream) {

--- a/test/tools/cli/OutputFormat.java
+++ b/test/tools/cli/OutputFormat.java
@@ -77,7 +77,8 @@ public enum OutputFormat {
     NONE {
         @Override
         public IonWriter createIonWriter(OutputStream outputStream) {
-            return IonTextWriterBuilder.pretty().build(outputStream);
+            NoOpOutputStream out = new NoOpOutputStream();
+            return IonTextWriterBuilder.pretty().build(out);
         }
 
         @Override

--- a/test/tools/cli/OutputFormat.java
+++ b/test/tools/cli/OutputFormat.java
@@ -42,6 +42,12 @@ public enum OutputFormat {
         public IonWriter createIonWriter(OutputStream outputStream) {
             return IonTextWriterBuilder.pretty().build(outputStream);
         }
+    },
+    NONE {
+        @Override
+        public IonWriter createIonWriter(OutputStream outputStream) {
+            return null;
+        }
     };
 
     abstract IonWriter createIonWriter(OutputStream outputStream);

--- a/test/tools/cli/OutputFormat.java
+++ b/test/tools/cli/OutputFormat.java
@@ -46,7 +46,7 @@ public enum OutputFormat {
     NONE {
         @Override
         public IonWriter createIonWriter(OutputStream outputStream) {
-            return null;
+            return IonTextWriterBuilder.pretty().build(outputStream);
         }
     };
 

--- a/test/tools/cli/OutputFormat.java
+++ b/test/tools/cli/OutputFormat.java
@@ -1,8 +1,13 @@
 package tools.cli;
 
 import com.amazon.ion.IonWriter;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.impl.SharedSymbolTableTest;
+import com.amazon.ion.impl._Private_IonValue;
+import com.amazon.ion.impl._Private_Utils;
 import com.amazon.ion.system.IonBinaryWriterBuilder;
 import com.amazon.ion.system.IonTextWriterBuilder;
+import tools.events.ImportDescriptor;
 
 import java.io.OutputStream;
 
@@ -18,6 +23,11 @@ public enum OutputFormat {
         public IonWriter createIonWriter(OutputStream outputStream) {
             return IonTextWriterBuilder.pretty().build(outputStream);
         }
+
+        @Override
+        public IonWriter createIonWriterWithImports(OutputStream outputStream, SymbolTable[] imports) {
+            return IonTextWriterBuilder.pretty().withImports(imports).build(outputStream);
+        }
     },
     /**
      * Minimally spaced text Ion.
@@ -26,6 +36,11 @@ public enum OutputFormat {
         @Override
         public IonWriter createIonWriter(OutputStream outputStream) {
             return IonTextWriterBuilder.standard().build(outputStream);
+        }
+
+        @Override
+        public IonWriter createIonWriterWithImports(OutputStream outputStream, SymbolTable[] imports) {
+            return IonTextWriterBuilder.standard().withImports(imports).build(outputStream);
         }
     },
     /**
@@ -36,6 +51,11 @@ public enum OutputFormat {
         public IonWriter createIonWriter(OutputStream outputStream) {
             return IonBinaryWriterBuilder.standard().build(outputStream);
         }
+
+        @Override
+        public IonWriter createIonWriterWithImports(OutputStream outputStream, SymbolTable[] imports) {
+            return IonBinaryWriterBuilder.standard().withImports(imports).build(outputStream);
+        }
     },
     /**
      * Event Stream
@@ -44,6 +64,11 @@ public enum OutputFormat {
         @Override
         public IonWriter createIonWriter(OutputStream outputStream) {
             return IonTextWriterBuilder.pretty().build(outputStream);
+        }
+
+        @Override
+        public IonWriter createIonWriterWithImports(OutputStream outputStream, SymbolTable[] imports) {
+            return IonTextWriterBuilder.pretty().withImports(imports).build(outputStream);
         }
     },
     /**
@@ -54,7 +79,13 @@ public enum OutputFormat {
         public IonWriter createIonWriter(OutputStream outputStream) {
             return IonTextWriterBuilder.pretty().build(outputStream);
         }
+
+        @Override
+        public IonWriter createIonWriterWithImports(OutputStream outputStream, SymbolTable[] imports) {
+            return IonTextWriterBuilder.pretty().withImports(imports).build(outputStream);
+        }
     };
 
     abstract IonWriter createIonWriter(OutputStream outputStream);
+    abstract IonWriter createIonWriterWithImports(OutputStream outputStream, SymbolTable[] symbolTable);
 }

--- a/test/tools/cli/ProcessContext.java
+++ b/test/tools/cli/ProcessContext.java
@@ -1,16 +1,19 @@
 package tools.cli;
 
+import tools.errorReport.ErrorType;
 import tools.events.EventType;
 
 public class ProcessContext {
     private String fileName;
     private int eventIndex;
     private EventType lastEventType;
+    private ErrorType state;
 
-    public ProcessContext(String file, int index, EventType lastEventType) {
+    public ProcessContext(String file, int index, EventType lastEventType, ErrorType state) {
         this.fileName = file;
         this.eventIndex = index;
         this.lastEventType = lastEventType;
+        this.state = state;
     }
 
     public String getFileName() {
@@ -25,6 +28,10 @@ public class ProcessContext {
         return this.lastEventType;
     }
 
+    public ErrorType getState() {
+        return state;
+    }
+
     public void setFileName(String fileName) {
         this.fileName = fileName;
     }
@@ -35,6 +42,10 @@ public class ProcessContext {
 
     public void setLastEventType(EventType lastEventType) {
         this.lastEventType = lastEventType;
+    }
+
+    public void setState(ErrorType state) {
+        this.state = state;
     }
 
 }

--- a/test/tools/cli/ProcessContext.java
+++ b/test/tools/cli/ProcessContext.java
@@ -1,5 +1,6 @@
 package tools.cli;
 
+import com.amazon.ion.IonWriter;
 import tools.errorReport.ErrorType;
 import tools.events.EventType;
 
@@ -8,12 +9,14 @@ public class ProcessContext {
     private int eventIndex;
     private EventType lastEventType;
     private ErrorType state;
+    private IonWriter ionWriter;
 
-    public ProcessContext(String file, int index, EventType lastEventType, ErrorType state) {
+    public ProcessContext(String file, int index, EventType lastEventType, ErrorType state, IonWriter ionWriter) {
         this.fileName = file;
         this.eventIndex = index;
         this.lastEventType = lastEventType;
         this.state = state;
+        this.ionWriter = ionWriter;
     }
 
     public String getFileName() {
@@ -48,4 +51,11 @@ public class ProcessContext {
         this.state = state;
     }
 
+    public IonWriter getIonWriter() {
+        return ionWriter;
+    }
+
+    public void setIonWriter(IonWriter ionWriter) {
+        this.ionWriter = ionWriter;
+    }
 }

--- a/test/tools/cli/ProcessContext.java
+++ b/test/tools/cli/ProcessContext.java
@@ -2,12 +2,12 @@ package tools.cli;
 
 import tools.events.EventType;
 
-public class CurrentInfo {
+public class ProcessContext {
     private String fileName;
     private int eventIndex;
     private EventType lastEventType;
 
-    public CurrentInfo(String file, int index, EventType lastEventType) {
+    public ProcessContext(String file, int index, EventType lastEventType) {
         this.fileName = file;
         this.eventIndex = index;
         this.lastEventType = lastEventType;

--- a/test/tools/errorReport/ErrorDescription.java
+++ b/test/tools/errorReport/ErrorDescription.java
@@ -1,0 +1,50 @@
+package tools.errorReport;
+
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonWriter;
+
+import java.io.IOException;
+
+public class ErrorDescription {
+    private final ErrorType errorType;
+    private final String message;
+    private final String location;
+    private final int eventIndex;
+
+    public ErrorDescription(ErrorType errorType, String message, String location, int eventIndex) {
+        this.errorType = errorType;
+        this.message = message;
+        this.location = location;
+        this.eventIndex = eventIndex;
+    }
+
+    public ErrorDescription(ErrorType errorType, String message, String location) {
+        this.errorType = errorType;
+        this.message = message;
+        this.location = location;
+        this.eventIndex = -99;
+    }
+
+    public void writeOutput(IonWriter ionWriterForErrorReport) throws IOException {
+        ionWriterForErrorReport.stepIn(IonType.STRUCT);
+        if (this.errorType != null) {
+            ionWriterForErrorReport.setFieldName("error_type");
+            ionWriterForErrorReport.writeSymbol(this.errorType.toString());
+        }
+        if (this.message != null) {
+            ionWriterForErrorReport.setFieldName("message");
+            ionWriterForErrorReport.writeString(this.message);
+        }
+        if (this.location != null) {
+            ionWriterForErrorReport.setFieldName("location");
+            ionWriterForErrorReport.writeString(this.location);
+        }
+
+        if(this.eventIndex != -99) {
+            ionWriterForErrorReport.setFieldName("event_index");
+            ionWriterForErrorReport.writeInt(this.eventIndex);
+        }
+
+        ionWriterForErrorReport.stepOut();
+    }
+}

--- a/test/tools/errorReport/ErrorDescription.java
+++ b/test/tools/errorReport/ErrorDescription.java
@@ -39,12 +39,10 @@ public class ErrorDescription {
             ionWriterForErrorReport.setFieldName("location");
             ionWriterForErrorReport.writeString(this.location);
         }
-
-        if(this.eventIndex != -1) {
+        if (this.eventIndex != -1) {
             ionWriterForErrorReport.setFieldName("event_index");
             ionWriterForErrorReport.writeInt(this.eventIndex);
         }
-
         ionWriterForErrorReport.stepOut();
     }
 }

--- a/test/tools/errorReport/ErrorDescription.java
+++ b/test/tools/errorReport/ErrorDescription.java
@@ -18,13 +18,6 @@ public class ErrorDescription {
         this.eventIndex = eventIndex;
     }
 
-    public ErrorDescription(ErrorType errorType, String message, String location) {
-        this.errorType = errorType;
-        this.message = message;
-        this.location = location;
-        this.eventIndex = -1;
-    }
-
     public void writeOutput(IonWriter ionWriterForErrorReport) throws IOException {
         ionWriterForErrorReport.stepIn(IonType.STRUCT);
         if (this.errorType != null) {

--- a/test/tools/errorReport/ErrorDescription.java
+++ b/test/tools/errorReport/ErrorDescription.java
@@ -22,7 +22,7 @@ public class ErrorDescription {
         this.errorType = errorType;
         this.message = message;
         this.location = location;
-        this.eventIndex = -99;
+        this.eventIndex = -1;
     }
 
     public void writeOutput(IonWriter ionWriterForErrorReport) throws IOException {
@@ -40,7 +40,7 @@ public class ErrorDescription {
             ionWriterForErrorReport.writeString(this.location);
         }
 
-        if(this.eventIndex != -99) {
+        if(this.eventIndex != -1) {
             ionWriterForErrorReport.setFieldName("event_index");
             ionWriterForErrorReport.writeInt(this.eventIndex);
         }

--- a/test/tools/errorReport/ErrorType.java
+++ b/test/tools/errorReport/ErrorType.java
@@ -1,0 +1,7 @@
+package tools.errorReport;
+
+public enum ErrorType {
+    READ,
+    WRITE,
+    STATE
+}

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -18,23 +18,13 @@ import java.io.IOException;
 public class Event {
     private static final int IO_ERROR_EXIT_CODE = 2;
 
-    private EventType eventType;
-    private IonType ionType;
-    private SymbolToken fieldName;
-    private SymbolToken[] annotations;
-    private IonValue value;
-    private ImportDescriptor[] imports;
-    private int depth;
-
-    public Event() {
-        this.eventType = null;
-        this.ionType = null;
-        this.fieldName = null;
-        this.annotations = null;
-        this.value = null;
-        this.imports = null;
-        this.depth = -1;
-    }
+    private final EventType eventType;
+    private final IonType ionType;
+    private final SymbolToken fieldName;
+    private final SymbolToken[] annotations;
+    private final IonValue value;
+    private final ImportDescriptor[] imports;
+    private final int depth;
 
     public Event(EventType eventType, IonType ionType, SymbolToken fieldName, SymbolToken[] annotations,
                  IonValue value, ImportDescriptor[] imports, int depth) {
@@ -49,20 +39,23 @@ public class Event {
 
     public void validate() throws IonException {
         if (this.eventType == null) throw new IonException("event_type can't be null");
-        else if (this.ionType == null
-                && (this.eventType != EventType.STREAM_END
-                    && this.eventType != EventType.SYMBOL_TABLE
-                    && this.eventType != EventType.CONTAINER_END))
-            throw new IonException("ion_type can't be null");
 
         EventType eventType = this.eventType;
         switch (eventType) {
             case CONTAINER_START:
-                if (!IonType.isContainer(this.ionType)) {
+                if (this.ionType == null || this.depth == -1) {
+                    throw new IonException("Invalid event_type: missing field(s)");
+                } else if (!IonType.isContainer(ionType)) {
                     throw new IonException("Invalid event_type: not a container");
                 }
                 break;
             case SCALAR:
+                if (this.ionType == null || this.value == null || this.depth == -1) {
+                    throw new IonException("Invalid event_type: missing field(s)");
+                } else if (IonType.isContainer(ionType)) {
+                    throw new IonException("Invalid event_type: ion_type error");
+                }
+                break;
             case SYMBOL_TABLE:
             case CONTAINER_END:
             case STREAM_END:
@@ -223,33 +216,5 @@ public class Event {
 
     public IonValue getValue() {
         return value;
-    }
-
-    public void setEventType(EventType eventType) {
-        this.eventType = eventType;
-    }
-
-    public void setIonType(IonType ionType) {
-        this.ionType = ionType;
-    }
-
-    public void setFieldName(SymbolToken fieldName) {
-        this.fieldName = fieldName;
-    }
-
-    public void setAnnotations(SymbolToken[] annotations) {
-        this.annotations = annotations;
-    }
-
-    public void setValue(IonValue value) {
-        this.value = value;
-    }
-
-    public void setImports(ImportDescriptor[] imports) {
-        this.imports = imports;
-    }
-
-    public void setDepth(int depth) {
-        this.depth = depth;
     }
 }

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -167,7 +167,7 @@ public class Event {
                 ionWriterForOutput.stepIn(IonType.LIST);
                 for (ImportDescriptor anImport : this.imports) {
                     ionWriterForOutput.stepIn(IonType.STRUCT);
-                    ionWriterForOutput.setFieldName("import_name");
+                    ionWriterForOutput.setFieldName("name");
                     ionWriterForOutput.writeString(anImport.getImportName());
                     ionWriterForOutput.setFieldName("version");
                     ionWriterForOutput.writeInt(anImport.getVersion());

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -37,34 +37,6 @@ public class Event {
         this.depth = depth;
     }
 
-    public void validate() throws IonException {
-        if (this.eventType == null) throw new IonException("event_type can't be null");
-
-        EventType eventType = this.eventType;
-        switch (eventType) {
-            case CONTAINER_START:
-                if (this.ionType == null || this.depth == -1) {
-                    throw new IonException("Invalid event_type: missing field(s)");
-                } else if (!IonType.isContainer(ionType)) {
-                    throw new IonException("Invalid event_type: not a container");
-                }
-                break;
-            case SCALAR:
-                if (this.ionType == null || this.value == null || this.depth == -1) {
-                    throw new IonException("Invalid event_type: missing field(s)");
-                } else if (IonType.isContainer(ionType)) {
-                    throw new IonException("Invalid event_type: ion_type error");
-                }
-                break;
-            case SYMBOL_TABLE:
-            case CONTAINER_END:
-            case STREAM_END:
-                break;
-            default:
-                throw new IonException("Invalid event_type");
-        }
-    }
-
     public void writeOutput(IonWriter ionWriterForErrorReport,
                             ProcessContext processContext) throws IOException {
         int updatedEventIndex = writeOutput(processContext.getIonWriter(), ionWriterForErrorReport,

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -65,10 +65,9 @@ public class Event {
         }
     }
 
-    public void writeOutput(IonWriter ionWriterForOutput,
-                            IonWriter ionWriterForErrorReport,
+    public void writeOutput(IonWriter ionWriterForErrorReport,
                             ProcessContext processContext) throws IOException {
-        int updatedEventIndex = writeOutput(ionWriterForOutput, ionWriterForErrorReport,
+        int updatedEventIndex = writeOutput(processContext.getIonWriter(), ionWriterForErrorReport,
                 processContext.getFileName(),processContext.getEventIndex());
 
         processContext.setEventIndex(updatedEventIndex);

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -47,11 +47,12 @@ public class Event {
         this.depth = depth;
     }
 
-    public void validate() throws IonException, IOException {
+    public void validate() throws IonException {
         if (this.eventType == null) throw new IonException("event_type can't be null");
         else if (this.ionType == null
                 && (this.eventType != EventType.STREAM_END
-                    && this.eventType != EventType.SYMBOL_TABLE))
+                    && this.eventType != EventType.SYMBOL_TABLE
+                    && this.eventType != EventType.CONTAINER_END))
             throw new IonException("ion_type can't be null");
 
         EventType eventType = this.eventType;

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -4,6 +4,8 @@ import com.amazon.ion.IonException;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolToken;
+import tools.cli.IonProcess;
+import tools.cli.IonProcess.CurrentInfo;
 import tools.errorReport.ErrorDescription;
 import tools.errorReport.ErrorType;
 
@@ -114,5 +116,14 @@ public class Event {
 
         //event index + 1 if we write OutputStream successfully.
         return eventIndex + 1;
+    }
+
+    public void writeOutput(IonWriter ionWriterForOutput,
+                           IonWriter ionWriterForErrorReport,
+                           CurrentInfo currentInfo) throws IOException {
+        int updatedEventIndex = writeOutput(ionWriterForOutput, ionWriterForErrorReport,
+                currentInfo.getFileName(),currentInfo.getEventIndex());
+        //event index + 1 if we write OutputStream successfully.
+        currentInfo.setEventIndex(updatedEventIndex);
     }
 }

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -4,7 +4,6 @@ import com.amazon.ion.IonException;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolToken;
-import tools.cli.IonProcess;
 import tools.cli.IonProcess.CurrentInfo;
 import tools.errorReport.ErrorDescription;
 import tools.errorReport.ErrorType;
@@ -33,6 +32,15 @@ public class Event {
         this.valueBinary = valueBinary;
         this.imports = imports;
         this.depth = depth;
+    }
+
+    public void writeOutput(IonWriter ionWriterForOutput,
+                            IonWriter ionWriterForErrorReport,
+                            CurrentInfo currentInfo) throws IOException {
+        int updatedEventIndex = writeOutput(ionWriterForOutput, ionWriterForErrorReport,
+                currentInfo.getFileName(),currentInfo.getEventIndex());
+
+        currentInfo.setEventIndex(updatedEventIndex);
     }
 
     /**
@@ -116,14 +124,5 @@ public class Event {
 
         //event index + 1 if we write OutputStream successfully.
         return eventIndex + 1;
-    }
-
-    public void writeOutput(IonWriter ionWriterForOutput,
-                           IonWriter ionWriterForErrorReport,
-                           CurrentInfo currentInfo) throws IOException {
-        int updatedEventIndex = writeOutput(ionWriterForOutput, ionWriterForErrorReport,
-                currentInfo.getFileName(),currentInfo.getEventIndex());
-
-        currentInfo.setEventIndex(updatedEventIndex);
     }
 }

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -7,7 +7,7 @@ import com.amazon.ion.IonReader;
 import com.amazon.ion.IonWriter;
 
 import com.amazon.ion.system.IonReaderBuilder;
-import tools.cli.CurrentInfo;
+import tools.cli.ProcessContext;
 import tools.errorReport.ErrorDescription;
 import tools.errorReport.ErrorType;
 
@@ -133,11 +133,11 @@ public class Event {
 
     public void writeOutput(IonWriter ionWriterForOutput,
                             IonWriter ionWriterForErrorReport,
-                            CurrentInfo currentInfo) throws IOException {
+                            ProcessContext processContext) throws IOException {
         int updatedEventIndex = writeOutput(ionWriterForOutput, ionWriterForErrorReport,
-                currentInfo.getFileName(),currentInfo.getEventIndex());
+                processContext.getFileName(),processContext.getEventIndex());
 
-        currentInfo.setEventIndex(updatedEventIndex);
+        processContext.setEventIndex(updatedEventIndex);
     }
 
     /**

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 
 public class Event {
     private static final int IO_ERROR_EXIT_CODE = 2;
-
     private final EventType eventType;
     private final IonType ionType;
     private final SymbolToken fieldName;

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -123,7 +123,7 @@ public class Event {
                            CurrentInfo currentInfo) throws IOException {
         int updatedEventIndex = writeOutput(ionWriterForOutput, ionWriterForErrorReport,
                 currentInfo.getFileName(),currentInfo.getEventIndex());
-        //event index + 1 if we write OutputStream successfully.
+
         currentInfo.setEventIndex(updatedEventIndex);
     }
 }

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -1,12 +1,17 @@
 package tools.events;
 
+import com.amazon.ion.IonException;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolToken;
+import tools.errorReport.ErrorDescription;
+import tools.errorReport.ErrorType;
 
 import java.io.IOException;
 
 public class Event {
+    private static final int IO_ERROR_EXIT_CODE = 2;
+
     private final EventType eventType;
     private final IonType ionType;
     private final SymbolToken fieldName;
@@ -28,70 +33,86 @@ public class Event {
         this.depth = depth;
     }
 
-    public void writeOutput(IonWriter ionWriterForOutput, IonWriter ionWriterForErrorReport) throws IOException {
-        ionWriterForOutput.stepIn(IonType.STRUCT);
-        if (this.eventType != null) {
-            ionWriterForOutput.setFieldName("event_type");
-            ionWriterForOutput.writeSymbol(this.eventType.toString());
-        }
-        if (this.ionType != null) {
-            ionWriterForOutput.setFieldName("ion_type");
-            ionWriterForOutput.writeSymbol(this.ionType.toString());
-        }
-        if (this.fieldName != null) {
-            ionWriterForOutput.setFieldName("field_name");
+    /**
+     * write Event structure to Ion Stream and return the updated eventIndex.
+     */
+    public int writeOutput(IonWriter ionWriterForOutput,
+                           IonWriter ionWriterForErrorReport,
+                           String fileName,
+                           int eventIndex) throws IOException {
+        try {
             ionWriterForOutput.stepIn(IonType.STRUCT);
-            ionWriterForOutput.setFieldName("text");
-            ionWriterForOutput.writeString(this.fieldName.getText());
-            ionWriterForOutput.stepOut();
-        }
-        if (this.annotations != null && this.annotations.length > 0) {
-            ionWriterForOutput.setFieldName("annotations");
-            ionWriterForOutput.stepIn(IonType.LIST);
-            for (int i = 0; i < this.annotations.length; i++) {
+            if (this.eventType != null) {
+                ionWriterForOutput.setFieldName("event_type");
+                ionWriterForOutput.writeSymbol(this.eventType.toString());
+            }
+            if (this.ionType != null) {
+                ionWriterForOutput.setFieldName("ion_type");
+                ionWriterForOutput.writeSymbol(this.ionType.toString());
+            }
+            if (this.fieldName != null) {
+                ionWriterForOutput.setFieldName("field_name");
                 ionWriterForOutput.stepIn(IonType.STRUCT);
                 ionWriterForOutput.setFieldName("text");
-                String text = this.annotations[i].getText();
-                if (text == null) {
-                    ionWriterForOutput.writeNull();
-                    ionWriterForOutput.setFieldName("import_location");
-                    ionWriterForOutput.writeNull();
-                } else {
-                    ionWriterForOutput.writeString(text);
+                ionWriterForOutput.writeString(this.fieldName.getText());
+                ionWriterForOutput.stepOut();
+            }
+            if (this.annotations != null && this.annotations.length > 0) {
+                ionWriterForOutput.setFieldName("annotations");
+                ionWriterForOutput.stepIn(IonType.LIST);
+                for (int i = 0; i < this.annotations.length; i++) {
+                    ionWriterForOutput.stepIn(IonType.STRUCT);
+                    ionWriterForOutput.setFieldName("text");
+                    String text = this.annotations[i].getText();
+                    if (text == null) {
+                        ionWriterForOutput.writeNull();
+                        ionWriterForOutput.setFieldName("import_location");
+                        ionWriterForOutput.writeNull();
+                    } else {
+                        ionWriterForOutput.writeString(text);
+                    }
+                    ionWriterForOutput.stepOut();
                 }
                 ionWriterForOutput.stepOut();
             }
-            ionWriterForOutput.stepOut();
-        }
-        if (this.valueText != null) {
-            ionWriterForOutput.setFieldName("value_text");
-            ionWriterForOutput.writeString(this.valueText);
-        }
-        if (this.valueBinary != null && this.valueBinary.length > 0) {
-            ionWriterForOutput.setFieldName("value_binary");
-            ionWriterForOutput.stepIn(IonType.LIST);
-            for (int i = 0; i < this.valueBinary.length; i++) {
-                ionWriterForOutput.writeInt(this.valueBinary[i] & 0xff);
-            }
-            ionWriterForOutput.stepOut();
-        }
-        if (this.imports != null && this.imports.length > 0) {
-            ionWriterForOutput.setFieldName("imports");
-            ionWriterForOutput.stepIn(IonType.LIST);
-            for (int i = 0; i < this.imports.length; i++) {
-                ionWriterForOutput.stepIn(IonType.STRUCT);
-                ionWriterForOutput.setFieldName("import_name");
-                ionWriterForOutput.writeString(this.imports[i].getImportName());
-                ionWriterForOutput.setFieldName("version");
-                ionWriterForOutput.writeInt(this.imports[i].getVersion());
-                ionWriterForOutput.setFieldName("max_id");
-                ionWriterForOutput.writeInt(this.imports[i].getMaxId());
+
+            if(this.valueText != null && this.valueBinary != null) {
+                ionWriterForOutput.setFieldName("value_text");
+                ionWriterForOutput.writeString(this.valueText);
+
+                ionWriterForOutput.setFieldName("value_binary");
+                ionWriterForOutput.stepIn(IonType.LIST);
+                for (int i = 0; i < this.valueBinary.length; i++) {
+                    ionWriterForOutput.writeInt(this.valueBinary[i] & 0xff);
+                }
                 ionWriterForOutput.stepOut();
             }
+
+            if (this.imports != null && this.imports.length > 0) {
+                ionWriterForOutput.setFieldName("imports");
+                ionWriterForOutput.stepIn(IonType.LIST);
+                for (int i = 0; i < this.imports.length; i++) {
+                    ionWriterForOutput.stepIn(IonType.STRUCT);
+                    ionWriterForOutput.setFieldName("import_name");
+                    ionWriterForOutput.writeString(this.imports[i].getImportName());
+                    ionWriterForOutput.setFieldName("version");
+                    ionWriterForOutput.writeInt(this.imports[i].getVersion());
+                    ionWriterForOutput.setFieldName("max_id");
+                    ionWriterForOutput.writeInt(this.imports[i].getMaxId());
+                    ionWriterForOutput.stepOut();
+                }
+                ionWriterForOutput.stepOut();
+            }
+            ionWriterForOutput.setFieldName("depth");
+            ionWriterForOutput.writeInt(this.depth);
             ionWriterForOutput.stepOut();
+        } catch (IonException e) {
+            new ErrorDescription(ErrorType.WRITE, e.getMessage(), fileName, eventIndex)
+                    .writeOutput(ionWriterForErrorReport);
+            System.exit(IO_ERROR_EXIT_CODE);
         }
-        ionWriterForOutput.setFieldName("depth");
-        ionWriterForOutput.writeInt(this.depth);
-        ionWriterForOutput.stepOut();
+
+        //event index + 1 if we write OutputStream successfully.
+        return eventIndex + 1;
     }
 }

--- a/test/tools/events/Event.java
+++ b/test/tools/events/Event.java
@@ -89,14 +89,17 @@ public class Event {
                            int eventIndex) throws IOException {
         try {
             ionWriterForOutput.stepIn(IonType.STRUCT);
+
             if (this.eventType != null) {
                 ionWriterForOutput.setFieldName("event_type");
                 ionWriterForOutput.writeSymbol(this.eventType.toString());
             }
+
             if (this.ionType != null) {
                 ionWriterForOutput.setFieldName("ion_type");
                 ionWriterForOutput.writeSymbol(this.ionType.toString());
             }
+
             if (this.fieldName != null) {
                 ionWriterForOutput.setFieldName("field_name");
                 ionWriterForOutput.stepIn(IonType.STRUCT);
@@ -110,6 +113,7 @@ public class Event {
                 ionWriterForOutput.writeNull();
                 ionWriterForOutput.stepOut();
             }
+
             if (this.annotations != null && this.annotations.length > 0) {
                 ionWriterForOutput.setFieldName("annotations");
                 ionWriterForOutput.stepIn(IonType.LIST);
@@ -146,7 +150,6 @@ public class Event {
                     ionWriterForOutput.setFieldName("value_text");
                     ionWriterForOutput.writeString(valueText);
 
-
                     //write binary
                     this.value.writeTo(binaryWriter);
                     binaryWriter.finish();
@@ -160,7 +163,6 @@ public class Event {
                     ionWriterForOutput.stepOut();
                 }
             }
-
 
             if (this.imports != null && this.imports.length > 0) {
                 ionWriterForOutput.setFieldName("imports");
@@ -177,10 +179,12 @@ public class Event {
                 }
                 ionWriterForOutput.stepOut();
             }
+
             if (this.depth != -1) {
                 ionWriterForOutput.setFieldName("depth");
                 ionWriterForOutput.writeInt(this.depth);
             }
+
             ionWriterForOutput.stepOut();
         } catch (IonException e) {
             new ErrorDescription(ErrorType.WRITE, e.getMessage(), fileName, eventIndex)

--- a/test/tools/events/ImportDescriptor.java
+++ b/test/tools/events/ImportDescriptor.java
@@ -3,14 +3,14 @@ package tools.events;
 import com.amazon.ion.SymbolTable;
 
 public class ImportDescriptor {
-    private String importName;
-    private int maxId;
-    private int version;
+    private final String importName;
+    private final int maxId;
+    private final int version;
 
-    public ImportDescriptor() {
-        this.importName = null;
-        this.maxId = -1;
-        this.version = -1;
+    public ImportDescriptor(String importName, int maxId, int version) {
+        this.importName = importName;
+        this.maxId = maxId;
+        this.version = version;
     }
 
     public ImportDescriptor(SymbolTable symbolTable) {
@@ -29,17 +29,5 @@ public class ImportDescriptor {
 
     public String getImportName() {
         return importName;
-    }
-
-    public void setImportName(String importName) {
-        this.importName = importName;
-    }
-
-    public void setMaxId(int maxId) {
-        this.maxId = maxId;
-    }
-
-    public void setVersion(int version) {
-        this.version = version;
     }
 }

--- a/test/tools/events/ImportDescriptor.java
+++ b/test/tools/events/ImportDescriptor.java
@@ -3,9 +3,15 @@ package tools.events;
 import com.amazon.ion.SymbolTable;
 
 public class ImportDescriptor {
-    private final String importName;
-    private final int maxId;
-    private final int version;
+    private String importName;
+    private int maxId;
+    private int version;
+
+    public ImportDescriptor() {
+        this.importName = null;
+        this.maxId = -1;
+        this.version = -1;
+    }
 
     public ImportDescriptor(SymbolTable symbolTable) {
         this.importName = symbolTable.getName();
@@ -13,15 +19,27 @@ public class ImportDescriptor {
         this.version = symbolTable.getVersion();
     }
 
-    final int getVersion() {
+    public int getVersion() {
         return version;
     }
 
-    final int getMaxId() {
+    public int getMaxId() {
         return maxId;
     }
 
-    final String getImportName() {
+    public String getImportName() {
         return importName;
+    }
+
+    public void setImportName(String importName) {
+        this.importName = importName;
+    }
+
+    public void setMaxId(int maxId) {
+        this.maxId = maxId;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
     }
 }


### PR DESCRIPTION
This pull request is based on pr1: https://github.com/cheqianh/ion-java/pull/1/files

What I did:
1. --output-format none
2. error report for reading 
3. embedded stream 
4. combined some functions to make code simpler 

Questions:
1. There are 3 error types, READ happens when reading ionStream to EventStream and WRITE happens when we read EventStream to ionStream right? what is STATE?

2. For constant, we use capital letters with underscore. Can I use this style for global variable? (for example, variable in inProcess.java 48-49)

3. When I read 2 files, there is an IVM between the EventStream of two files. ion-c doesn't have that.
For example:

my command is: ion-java process -f events file1 file2 and there is a IVM for the output
output:
{                                                                       
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eventType: ...                                                                 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ionType: ...                                                                      
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;...                                                                                     
}     
......                                                                                    
{                                                                                         
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eventType: STREAM_END                                             
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;depth: 0                                                                          
}                                                                         
**$ion_1_0**
output:
{                                                                       
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eventType: ...                                                                 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ionType: ...                                                                      
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;...                                                                                     
}       
......                                                                                  
{                                                                                         
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eventType: STREAM_END                                             
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;depth: 0                                                                          
}                                                                         



