### PR TITLE
compare mode exit for read errors

### DIFF
--- a/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
+++ b/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
@@ -829,6 +829,9 @@ public class IonJavaCli {
 
     private static void validateEventStream(List<Event> events) {
         if (events.size() == 0) return;
+        if (events.get(events.size() - 1).getEventType() != EventType.STREAM_END) {
+            throw new IonException("Invalid event stream: event stream end without STREAM_END event");
+        }
 
         int depth = 0;
         int i = -1;


### PR DESCRIPTION
Compare mode will exit immediately when it detects read error. 

So we don't run compare logic if we don't even get the correct List\<Event\>