### PR TITLE
handle symbol zero annotation from event stream

### DIFF
--- a/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
+++ b/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
@@ -1067,12 +1067,12 @@ public class IonJavaCli {
                     ionReader.stepIn();
                     while (ionReader.next() != null) {
                         ionReader.stepIn();
-                        String text = "";
+                        String text = null;
                         int sid = 0;
                         while (ionReader.next() != null) {
                             switch (ionReader.getFieldName()) {
                                 case "text":
-                                    text = ionReader.stringValue();
+                                    text = ionReader.isNullValue() ? null : ionReader.stringValue();
                                     break;
                                 case "sid":
                                     sid = ionReader.intValue();
@@ -1083,7 +1083,7 @@ public class IonJavaCli {
                         annotationsList.add(annotation);
                         ionReader.stepOut();
                     }
-                    annotations = annotationsList.toArray(new SymbolToken[0]);
+                    annotations = annotationsList.toArray(SymbolToken.EMPTY_ARRAY);
                     ionReader.stepOut();
                     break;
                 case "value_text":


### PR DESCRIPTION
Given a symbol zero annotation event 
{
&nbsp;&nbsp; ......
&nbsp;&nbsp; annotation: {text: null, sid: 0}
&nbsp;&nbsp; ......
}

it will convert to $0:: in ionStream while it throws an exception before.