### PR TITLE
eventStream without stream_end is tolerated

### DIFF
--- a/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
+++ b/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
@@ -826,9 +826,6 @@ public class IonJavaCli {
 
     private static void validateEventStream(List<Event> events) {
         if (events.size() == 0) return;
-        if (events.get(events.size() - 1).getEventType() != EventType.STREAM_END) {
-            throw new IonException("Invalid event stream: event stream end without STREAM_END event");
-        }
 
         int depth = 0;
         int i = -1;


### PR DESCRIPTION
EventStream without stream_end is tolerated because we may compare incomplete event stream from bad vector files.